### PR TITLE
Minor change to make --inputs-file work

### DIFF
--- a/exe/timing_attack
+++ b/exe/timing_attack
@@ -53,7 +53,7 @@ class TimingAttackCli
       opts.on("-q", "--quiet", "Quiet mode (don't display progress bars)") { |bool| options[:verbose] = !bool }
       opts.on("-b", "--brute-force", "Brute force mode") { |bool| options[:brute_force] = bool }
       opts.on("-i FILE", "--inputs-file FILE", "Read inputs from specified file, one per line") do |str|
-        options[:inputs] = flat_file(filename)
+        options[:inputs] = flat_file(str)
       end
       opts.on("--parameters STR", "JSON hash of URL parameters.  'INPUT' will be replaced with the attack string") do |str|
         options[:params] = JSON.parse(str)


### PR DESCRIPTION
Without it the gem throws an error:

`.rvm/gems/ruby-2.1.10/gems/timing_attack-0.7.0/exe/timing_attack:56:in `block (2 levels) in opt_parser': undefined local variable or method `filename' for #<TimingAttackCli:0x000000014a6630> (NameError)`